### PR TITLE
added support for python 3.9

### DIFF
--- a/baseconvert/baseconvert.py
+++ b/baseconvert/baseconvert.py
@@ -115,7 +115,16 @@ Max fractional depth:
 
 
 # Greatest common denominator is used when converting fractions.
-from fractions import gcd
+import sys
+
+
+major = str(sys.version_info[0])
+minor = str(sys.version_info[1])
+python_version = float(major + "." + minor)
+if python_version >= 3.9:
+    from math import gcd
+else:
+    from fractions import gcd
 
 
 class BaseConverter:


### PR DESCRIPTION
This PR adds support for python 3.9 without breaking backward compatibility with versions below 3.9.

https://stackoverflow.com/questions/66174862/import-error-cant-import-name-gcd-from-fractions